### PR TITLE
Fixed: grid doesn't refresh when _gridOptions.data is an empty array

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "vsicons.presets.angular": false
+}

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-data-grid",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "homepage": "https://github.com/angular-data-grid/angular-data-grid.github.io",
   "authors": [
     "Zhuk",

--- a/contributors.txt
+++ b/contributors.txt
@@ -1,2 +1,3 @@
 Eugene Draitsev
 Ivan Bisultanov
+Rick Zakharov

--- a/src/js/dataGrid.js
+++ b/src/js/dataGrid.js
@@ -38,7 +38,7 @@
             $scope.urlSync = $scope._gridOptions.urlSync;
 
             $scope.$watch('_gridOptions.data', function (newValue) {
-                if (newValue && newValue.length) {
+                if (newValue && newValue.length > -1) {
                     $scope.sortCache = {};
                     $scope.filtered = $scope._gridOptions.data.slice();
                     $scope.filters.forEach(function (filter) {


### PR DESCRIPTION
Hi,

Please see a fix that would make the grid refresh when you assign empty array to gridOptions.data

Cheers,
Rick