### PR TITLE
Support for ES6 imports was added

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,0 +1,7 @@
+require('./dist/dataGrid');
+require('./dist/pagination');
+
+module.exports = {
+    dataGrid: 'dataGrid',
+    pagination: 'pagination',
+};

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "gulp-uglify": "^1.4.2"
   },
   "description": "Light, flexible and performant Data Grid for AngularJS apps, with built-in sorting, pagination and filtering options, unified API for client-side and server-side data fetching, \r seamless synchronization with browser address bar and total freedom in mark-up and styling suitable for your application. Angular 1.3 - 1.6 compliant.",
-  "main": "index.html",
+  "main": "index.js",
   "devDependencies": {},
   "repository": {
     "type": "git",


### PR DESCRIPTION
It's needed for allowing the es6 imports like this:

```
import { dataGrid, pagination } from 'angular-data-grid';

/**
 * @ngInject
 */
export default angular
  .module('app.dependencies', [
    dataGrid,
    pagination,
  ]).name;
```